### PR TITLE
feature - added countdown tile

### DIFF
--- a/resources/assets/css/components/count-down.css
+++ b/resources/assets/css/components/count-down.css
@@ -1,0 +1,31 @@
+.count-down {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.count-down__group {
+    display: flex;
+    padding: .1em 0;
+    color: var(--yellow);
+    letter-spacing: .05em;
+    font-weight: var(--font-weight-light);
+    font-size: var(--font-size-l);
+    text-align: center;
+    line-height: 1;
+    margin: 0 .5em
+}
+
+.count-down__block {
+    margin: 0 .5em;
+}
+
+.count-down__value {
+    font-size: var(--font-size-xl);
+}
+
+.count-down__name {
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    text-align: center;
+}

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -12,6 +12,7 @@ import Music from './components/Music';
 import Packagist from './components/Packagist';
 import Tasks from './components/Tasks';
 import TimeWeather from './components/TimeWeather';
+import CountDown from './components/CountDown.vue';
 import Twitter from './components/Twitter';
 import Uptime from './components/Uptime';
 
@@ -29,6 +30,7 @@ new Vue({
         Packagist,
         Tasks,
         TimeWeather,
+        CountDown,
         Twitter,
         Uptime,
     },

--- a/resources/assets/js/components/CountDown.vue
+++ b/resources/assets/js/components/CountDown.vue
@@ -1,0 +1,80 @@
+<template>
+    <tile :position="position">
+        <section class="count-down">
+            <div class="count-down__content">
+                <div class="count-down__name">{{ name }}</div>
+                <div class="count-down__group">
+                    <div v-for="(value, key) in countDown" class="count-down__block">
+                        <div class="count-down__value">{{ value }}</div>
+                        <div class="count-down__name">{{ key }}{{ value == 1 ? '' : 's'}}</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </tile>
+</template>
+
+<script>
+    import Tile from './atoms/Tile';
+    import moment from 'moment-timezone';
+
+    export default {
+
+        components: {
+            Tile,
+        },
+
+        props: {
+            name: {
+                type: String,
+            },
+            cron: {
+                type: String,
+                default: '55 10 * * 1-5',
+            },
+            duration: {
+                type: Number,
+                default: 800, //15 minutes
+            },
+            position: {
+                type: String,
+            },
+        },
+
+        data() {
+            return {
+                next: moment(),
+                time: moment(),
+            };
+        },
+
+        computed: {
+            countDown: function () {
+                var duration = moment.duration(this.next - this.time);
+                return {
+                    day: duration.days(),
+                    hour: duration.hours(),
+                    minute: duration.minutes(),
+                    second: duration.seconds(),
+                };
+            },
+        },
+
+        created() {
+            this.init();
+            setInterval(this.refreshTime, 1000);
+        },
+
+        methods: {
+            init() {
+                var parser = require('cron-parser');
+                var interval = parser.parseExpression(this.cron);
+                this.next = moment(interval.next().toISOString());
+            },
+
+            refreshTime() {
+                this.time = moment();
+            },
+        },
+    };
+</script>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -10,6 +10,8 @@
     <github-project position="a2" project="SOL"></github-project>
     <github-project position="a3" project="SOL-management"></github-project>
     <time-weather position="b1" date-format="DD/MM/YYYY" time-format="HH:mm:ss" time-zone="Europe/Brussels" weather-city="Gent"></time-weather>
+    <count-down position="b2" name="Standup" cron="0 11 * * 1-4"></count-down>
+    <count-down position="b3" name="Development vergadering" cron="0 10 * * 5"></count-down>
     <internet-connection></internet-connection>
 </dashboard>
 


### PR DESCRIPTION
Basis van een countdown die via cron werkt. 
De bedoeling is om dit later nog uit te breiden met:

- eenmaal de countdown bereikt is een waarschuwing mee te geven (zichtbaar of via geluid)
- Vanaf dan ook een timer in te stellen (duur van standups)
- De tile ook onzichtbaar te maken (dit is iets waar we niet constant in geinteresseerd zijn) En enkele vanaf een bepaald moment (vb 5 min voor de standup) met een overlay te werken waarop de countdown zichtbaar is